### PR TITLE
Fix tooltip text for abs and log

### DIFF
--- a/static/scripts/script.js
+++ b/static/scripts/script.js
@@ -1486,12 +1486,12 @@ function initializeOperatorButtons() {
         { 
             symbol: 'abs', 
             type: 'function',
-            tooltip: 'Absolute Value\nExample: abs(-5) = 5\n\nParenthesis added automatically\nRemoves the negative sign\nReturns how far a number is from zero'
+            tooltip: 'Absolute Value\nExample: abs(-5) = 5\n\nParentheses added automatically\nRemoves the negative sign\nReturns how far a number is from zero'
         },
         { 
             symbol: 'log', 
             type: 'function',
-            tooltip: 'Base-10 Logarithm\nExample: log(100) = 2\n\nParenthesis added automatically\nAnswers: "10 to what power gives this number?"\n\nlog(1000) = 3 because 10³ = 1000'
+            tooltip: 'Base-10 Logarithm\nExample: log(100) = 2\n\nParentheses added automatically\nAnswers: "10 to what power gives this number?"\n\nlog(1000) = 3 because 10³ = 1000'
         },
         { 
             symbol: '!', 


### PR DESCRIPTION
## Summary
- update tooltip messages for abs and log operators

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f768850d883309b27e77223818f46