### PR TITLE
Fix multiplication handling and scoring

### DIFF
--- a/static/scripts/mathUtils.js
+++ b/static/scripts/mathUtils.js
@@ -48,6 +48,8 @@ export function safeEval(expression) {
  */
 function cleanExpression(expression) {
     return expression
+        // Convert multiplication symbol
+        .replace(/x/g, '*')
         // Convert square root symbol to sqrt
         .replace(/√(\d+)/g, 'sqrt($1)')
         .replace(/√\(/g, 'sqrt(')

--- a/static/scripts/script.js
+++ b/static/scripts/script.js
@@ -1173,8 +1173,8 @@ function formatSolutionForSharing(solution) {
         return 'Error formatting solution';
     }
     
-    const left = solution.left.replace(/[+\-X/%^√!]|abs|log/g, '□');
-    const right = solution.right.replace(/[+\-X/%^√!]|abs|log/g, '□');
+    const left = solution.left.replace(/[+\-x*/%^√!]|abs|log/g, '□');
+    const right = solution.right.replace(/[+\-x*/%^√!]|abs|log/g, '□');
     return `${left} = ${right}\n${solution.points} points${solution.hardMode ? ' (Hard Mode)' : ''}`;
 }
 
@@ -1571,12 +1571,12 @@ function setupActionButtonListeners() {
 function calculatePoints(expression) {
     const pointValues = {
         '+': 1, '-': 1,
-        '*': 2, '/': 2, '%': 2,
+        '*': 2, 'x': 2, '/': 2, '%': 2,
         '^': 3, '√': 3,
         '!': 4, 'abs': 4, 'log': 4
     };
-    
-    return expression.split(/([+\-*/%^√!]|abs|log)/).reduce((points, char) => 
+
+    return expression.split(/([+\-x*/%^√!]|abs|log)/).reduce((points, char) =>
         points + (pointValues[char] || 0), 0);
 }
 


### PR DESCRIPTION
## Summary
- support `x` symbol when evaluating expressions
- count `x` operator towards score
- sanitize solutions containing `x` when sharing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f77030b98833098c40d52ecd90ee2