### PR TITLE
Add drag-and-drop math input

### DIFF
--- a/static/scripts/script.js
+++ b/static/scripts/script.js
@@ -3,6 +3,7 @@ import { safeEval } from './mathUtils.js';
 let digits = [];
 let digitIndex = 0;
 let activeSide = 'left';
+let dragData = null; // info about current drag
 
 const leftSide = document.getElementById('left-side');
 const rightSide = document.getElementById('right-side');
@@ -35,22 +36,54 @@ function createButton(text, cls) {
   return btn;
 }
 
-function appendToken(text) {
-  const container = activeSide === 'left' ? leftSide : rightSide;
-  const btn = createButton(text);
-  btn.addEventListener('click', () => {
-    btn.remove();
-    update();
-  });
-  container.appendChild(btn);
-  update();
+function createToken(text, type) {
+  const el = document.createElement('span');
+  el.className = `token ${type}`;
+  el.textContent = text;
+  el.dataset.value = text;
+  el.dataset.type = type;
+  el.draggable = true;
+  el.addEventListener('click', () => { el.remove(); update(); });
+  el.addEventListener('dragstart', onTokenDragStart);
+  el.addEventListener('dragover', e => e.preventDefault());
+  el.addEventListener('drop', onTokenDrop);
+  return el;
 }
 
 function expressionFrom(container) {
-  return Array.from(container.children).map(b => b.textContent).join('');
+  return Array.from(container.children).map(c => c.dataset.value).join('');
+}
+
+function combineFractions(container) {
+  const children = Array.from(container.children);
+  for (let i = 0; i < children.length - 2; i++) {
+    const a = children[i];
+    const op = children[i + 1];
+    const b = children[i + 2];
+    if (a.dataset.type === 'number' && op.dataset.value === '/' && b.dataset.type === 'number') {
+      const frac = document.createElement('span');
+      frac.className = 'token fraction';
+      frac.dataset.type = 'fraction';
+      frac.dataset.value = `${a.dataset.value}/${b.dataset.value}`;
+      frac.draggable = true;
+      frac.innerHTML = `<span class="numerator">${a.textContent}</span><span class="line"></span><span class="denominator">${b.textContent}</span>`;
+      frac.addEventListener('click', () => { frac.remove(); update(); });
+      frac.addEventListener('dragstart', onTokenDragStart);
+      frac.addEventListener('dragover', e => e.preventDefault());
+      frac.addEventListener('drop', onTokenDrop);
+      container.insertBefore(frac, a);
+      container.removeChild(a);
+      container.removeChild(op);
+      container.removeChild(b);
+      children.splice(i, 3, frac);
+      i--;
+    }
+  }
 }
 
 function update() {
+  combineFractions(leftSide);
+  combineFractions(rightSide);
   const leftExpr = expressionFrom(leftSide);
   const rightExpr = expressionFrom(rightSide);
   const leftVal = safeEval(leftExpr);
@@ -88,6 +121,7 @@ function reset() {
   rightSide.innerHTML = '';
   digitIndex = 0;
   activeSide = 'left';
+  dragData = null;
   document.querySelectorAll('#date-buttons .number').forEach(btn => {
     btn.disabled = false;
     btn.classList.remove('disabled');
@@ -111,10 +145,71 @@ function check() {
   }
 }
 
+function onDigitDragStart(e) {
+  const idx = Number(e.target.dataset.index);
+  if (idx !== digitIndex) {
+    showMessage('Use numbers in order');
+    e.preventDefault();
+    return;
+  }
+  dragData = { source: 'digit', text: e.target.textContent, element: e.target, index: idx };
+  e.dataTransfer.setData('text/plain', dragData.text);
+}
+
+function onOpDragStart(e) {
+  const op = e.target.textContent;
+  const text = ['abs', 'log', '√'].includes(op) ? op + '(' : op;
+  dragData = { source: 'operator', text, element: e.target };
+  e.dataTransfer.setData('text/plain', text);
+}
+
+function onTokenDragStart(e) {
+  dragData = { source: 'token', element: e.target, text: e.target.dataset.value };
+  e.dataTransfer.setData('text/plain', dragData.text);
+}
+
+function onTokenDrop(e) {
+  e.preventDefault();
+  const before = e.currentTarget.classList.contains('token') ? e.currentTarget : null;
+  const container = before ? before.parentElement : e.currentTarget;
+  insertDraggedToken(container, before);
+}
+
+function insertDraggedToken(container, before) {
+  if (!dragData) return;
+  let tokenEl;
+  if (dragData.source === 'digit') {
+    if (dragData.index !== digitIndex) {
+      showMessage('Use numbers in order');
+      dragData = null;
+      return;
+    }
+    dragData.element.disabled = true;
+    dragData.element.classList.add('disabled');
+    digitIndex++;
+    tokenEl = createToken(dragData.text, 'number');
+  } else if (dragData.source === 'operator') {
+    tokenEl = createToken(dragData.text, 'operator');
+  } else if (dragData.source === 'token') {
+    tokenEl = dragData.element;
+  }
+
+  if (before) {
+    container.insertBefore(tokenEl, before);
+  } else {
+    container.appendChild(tokenEl);
+  }
+  dragData = null;
+  update();
+}
+
 function setupNumberButtons() {
   const container = document.getElementById('date-buttons');
   digits.forEach((n, i) => {
     const btn = createButton(String(n), 'number');
+    btn.dataset.index = i;
+    btn.draggable = true;
+    btn.addEventListener('dragstart', onDigitDragStart);
     btn.addEventListener('click', () => {
       if (i !== digitIndex) {
         showMessage('Use numbers in order');
@@ -123,7 +218,9 @@ function setupNumberButtons() {
       btn.disabled = true;
       btn.classList.add('disabled');
       digitIndex++;
-      appendToken(String(n));
+      const tokenEl = createToken(String(n), 'number');
+      (activeSide === 'left' ? leftSide : rightSide).appendChild(tokenEl);
+      update();
     });
     container.appendChild(btn);
   });
@@ -134,11 +231,23 @@ function setupOperatorButtons() {
   const container = document.getElementById('operator-buttons');
   ops.forEach(op => {
     const btn = createButton(op, 'operator');
+    btn.draggable = true;
+    btn.addEventListener('dragstart', onOpDragStart);
     btn.addEventListener('click', () => {
       const text = ['abs', 'log', '√'].includes(op) ? op + '(' : op;
-      appendToken(text);
+      const tokenEl = createToken(text, 'operator');
+      (activeSide === 'left' ? leftSide : rightSide).appendChild(tokenEl);
+      update();
     });
     container.appendChild(btn);
+  });
+}
+
+function setupSides() {
+  [leftSide, rightSide].forEach(side => {
+    side.addEventListener('dragover', e => e.preventDefault());
+    side.addEventListener('drop', onTokenDrop);
+    side.addEventListener('click', () => { activeSide = side.id === 'left-side' ? 'left' : 'right'; });
   });
 }
 
@@ -152,10 +261,9 @@ function init() {
   themeToggle.addEventListener('click', toggleTheme);
   setupNumberButtons();
   setupOperatorButtons();
+  setupSides();
   document.getElementById('clear-button').addEventListener('click', reset);
   document.getElementById('check-button').addEventListener('click', check);
-  leftSide.addEventListener('click', () => (activeSide = 'left'));
-  rightSide.addEventListener('click', () => (activeSide = 'right'));
   update();
 }
 

--- a/static/styles/styles.css
+++ b/static/styles/styles.css
@@ -62,7 +62,7 @@ body {
 }
 
 .button-container button,
-.equation-side button {
+.equation-side .token {
     padding: 0.5rem 0.75rem;
     border: none;
     background: var(--surface-color);
@@ -73,7 +73,7 @@ body {
 }
 
 .button-container button:hover:not(:disabled),
-.equation-side button:hover {
+.equation-side .token:hover {
     background: var(--accent-color);
     color: #fff;
 }
@@ -142,4 +142,27 @@ body {
 
 .success {
     color: var(--accent-color);
+}
+
+.token {
+    user-select: none;
+    cursor: move;
+}
+
+.fraction {
+    padding: 0;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.fraction .line {
+    width: 100%;
+    border-bottom: 1px solid var(--text-color);
+    margin: 2px 0;
+}
+
+.fraction .numerator,
+.fraction .denominator {
+    padding: 0 0.25rem;
 }


### PR DESCRIPTION
## Summary
- enable drag and drop of digits and operators
- support moving tokens around on each side
- convert simple `a/b` patterns into fraction display
- style draggable tokens and fractions

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a062870b48330a1f6091515c6c230